### PR TITLE
Added utf-8 decode to byte string response

### DIFF
--- a/os1/core.py
+++ b/os1/core.py
@@ -118,7 +118,7 @@ class OS1API(object):
             while not response.endswith(b"\n"):
                 response += sock.recv(1024)
         self._error_check(response)
-        return response
+        return response.decode("utf-8")
 
     def _error_check(self, response):
         response = response.decode("utf-8")


### PR DESCRIPTION
I was getting the following error when trying to use the client.
```
Traceback (most recent call last):
  File "recipe.py", line 39, in <module>
    beam_intrinsics = json.loads(os1.get_beam_intrinsics())
  File "/home/ben/.pyenv/versions/3.5.7/lib/python3.5/json/__init__.py", line 312, in loads
    s.__class__.__name__))
TypeError: the JSON object must be str, not 'bytes'
```
I added the decode function to the response and it seems to have resolved the issue.

Python: 3.5.7
Firmware: 1.12